### PR TITLE
Fix merlin_completion_with_doc on Vim8

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_ocaml.py
+++ b/rplugin/python3/deoplete/sources/deoplete_ocaml.py
@@ -37,7 +37,7 @@ class Source(Base):
         return self.vim.eval('exists("{0}") ? {0} : []'.format(name))
 
     def on_init(self, context): # called by deoplete
-        self.merlin_completion_with_doc = self._is_set("merlin_completion_with_doc")
+        self.merlin_completion_with_doc = self._is_set("g:merlin_completion_with_doc")
         self.merlin_binary = self.vim.eval("merlin#SelectBinary()")
         self.merlin_binary_flags = self.vim.eval('g:merlin_binary_flags')
         self.buffer_merlin_flags = self._list_if_set('b:merlin_flags')


### PR DESCRIPTION
To reproduce:
* add `let g:merlin_completion_with_doc = 1` to `.vimrc`
* type `List.map` in a `.ml` file and select the `map` completion

On `NVIM v0.2.0` this works fine, I see the doc associated with `List.map`, however on `VIM 8.0` I see just the type and not the doc.
Looks like `exists("merlin_completion_with_doc")` returned false on Vim 8 with `nvim-yarp` and `vim-hug-neovim-rpc`.

If I  change it to use `g:merlin_completion_with_doc` then it works both in `VIM 8` and `NVIM 0.2.0`.